### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,38 +2,37 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Weather 	KEYWORD1
+Weather	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getRH	                KEYWORD2
-readTemp		KEYWORD2
-getTemp			KEYWORD2
-readTempF	        KEYWORD2
-getTempF		KEYWORD2
-heaterOn	        KEYWORD2
-heaterOff 		KEYWORD2
+getRH	KEYWORD2
+readTemp	KEYWORD2
+getTemp	KEYWORD2
+readTempF	KEYWORD2
+getTempF	KEYWORD2
+heaterOn	KEYWORD2
+heaterOff	KEYWORD2
 changeResolution	KEYWORD2
-Reset			KEYWORD2
-checkID			KEYWORD2
+Reset	KEYWORD2
+checkID	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
 
 
-ADDRESS	        	LITERAL1
+ADDRESS	LITERAL1
 
 TEMP_MEASURE_HOLD	LITERAL1
 HUMD_MEASURE_HOLD	LITERAL1
 TEMP_MEASURE_NOHOLD	LITERAL1
 HUMD_MEASURE_NOHOLD	LITERAL1
-TEMP_PREV		LITERAL1
+TEMP_PREV	LITERAL1
 
-WRITE_USER_REG 	LITERAL1
-READ_USER_REG 	LITERAL1
+WRITE_USER_REG	LITERAL1
+READ_USER_REG	LITERAL1
 SOFT_RESET	LITERAL1
-HTRE	        LITERAL1
+HTRE	LITERAL1
 CRC_POLY	LITERAL1
-    


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords