### PR TITLE
Only serial-print device ID in DEBUG.

### DIFF
--- a/src/SparkFun_Si7021_Breakout_Library.cpp
+++ b/src/SparkFun_Si7021_Breakout_Library.cpp
@@ -45,6 +45,7 @@
 {
   Wire.begin();
 
+#ifdef DEBUG
   uint8_t ID_Temp_Hum = checkID();
 
   int x = 0;
@@ -69,6 +70,7 @@
   else
   	Serial.println("No Devices Detected");
   	//Serial.println(ID_Temp_Hum, HEX);
+#endif
 }
 
 /****************Si7021 & HTU21D Functions**************************************/


### PR DESCRIPTION
Device ID prints take up valuable flash, are not useful after prototyping / debugging